### PR TITLE
Extra check if strings are true/false values

### DIFF
--- a/src/godotconversions.cpp
+++ b/src/godotconversions.cpp
@@ -484,8 +484,12 @@ bool convert<Variant>::decode(const YAML::Node &node, Variant &variant) {
 	} catch (::YAML::TypedBadConversion<double> err) {
 	}
 	try {
-		variant = node.as<bool>();
-		return true;
+		const std::string str = node.as<std::string>();
+		if (str == "true" || str == "false") {
+			variant = node.as<bool>();
+			return true;
+		}
+		throw ::YAML::TypedBadConversion<bool>(node.Mark());
 	} catch (::YAML::TypedBadConversion<bool> err) {
 	}
 	// Probably catches anything else (except empty values)


### PR DESCRIPTION
This fixes conversions of strings like `y`/`n`, `yes`/`no`, possibly
others too.

I talked with the guys at the yaml-cpp and they maintain it's not their fault, but they put me on track on how to solve it.

closes #4 